### PR TITLE
op-dachallenger

### DIFF
--- a/op-dachallenger/challenge/actor.go
+++ b/op-dachallenger/challenge/actor.go
@@ -1,0 +1,212 @@
+package challenge
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/scheduler"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	plasma "github.com/ethereum-optimism/optimism/op-plasma"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type ActorMetricer interface {
+	RecordLastActedL1Block(n uint64)
+	RecordActedL1Ref(ref eth.L1BlockRef)
+}
+
+type Actor struct {
+	resolver   *scheduler.ResolveScheduler
+	challenger *scheduler.ChallengeScheduler
+
+	plasmaFetcher types.PlasmaFetcher
+	l1Fetcher     derive.L1Fetcher
+	blobsFetcher  *sources.L1BeaconClient
+	rollupCfg     *rollup.Config
+	dsConfig      derive.DataSourceConfig
+
+	l1FinalizedSig chan eth.L1BlockRef
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
+
+	logger  log.Logger
+	metrics ActorMetricer
+}
+
+func NewActor(logger log.Logger, m ActorMetricer, r *scheduler.ResolveScheduler, c *scheduler.ChallengeScheduler,
+	damgr types.PlasmaFetcher, l1Fetcher derive.L1Fetcher, blobsFetcher *sources.L1BeaconClient,
+	rollCfg *rollup.Config) (*Actor, error) {
+	if r == nil && c == nil {
+		return nil, errors.New("actor needs to be configured with a challenger or a resolver, or both")
+	}
+	dsConfig := derive.DataSourceConfig{
+		L1Signer:          rollCfg.L1Signer(),
+		BatchInboxAddress: rollCfg.BatchInboxAddress,
+		PlasmaEnabled:     true,
+	}
+	return &Actor{
+		logger:         logger,
+		metrics:        m,
+		resolver:       r,
+		challenger:     c,
+		plasmaFetcher:  damgr,
+		blobsFetcher:   blobsFetcher,
+		rollupCfg:      rollCfg,
+		dsConfig:       dsConfig,
+		l1Fetcher:      l1Fetcher,
+		l1FinalizedSig: make(chan eth.L1BlockRef),
+	}, nil
+}
+
+func (a *Actor) OnNewL1Finalized(ctx context.Context, finalized eth.L1BlockRef) {
+	select {
+	case <-ctx.Done():
+		return
+	case a.l1FinalizedSig <- finalized:
+		return
+	}
+}
+
+// Questions:
+// Is it sufficient to only attempt to challenge the commitment once? E.g. on every new finalized block
+// we identify new commitments in that block, and check if we can retrieve the input. IFF we can't then we
+// create a new challenge. If we can, we do not and do not come back to check at a later time.
+
+// Similarly, if we see a new challenge in a new finalized block do we only attempt to resolve once or do we retry
+// on every subsequent block until we can either resolve or the resolveWindow expires?
+
+// Start the DA challenge/resolve loop
+func (a *Actor) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	a.cancel = cancel
+	a.resolver.Start(ctx)
+	a.wg.Add(1)
+	go a.run(ctx)
+}
+
+func (a *Actor) run(ctx context.Context) {
+	defer a.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ref := <-a.l1FinalizedSig:
+			// TODO: consider also handling retry logic for the entire challenge_window
+			// TODO: ensure it is OK to use latest finalized as L1 origin
+			// it should be fine as long as resolve_window and challenge_window are significantly longer than 64 slots
+			var src derive.DataIter
+			if a.rollupCfg.EcotoneTime != nil && ref.Time >= *a.rollupCfg.EcotoneTime {
+				if a.blobsFetcher == nil {
+					a.logger.Error("ecotone upgrade active but beacon endpoint not configured")
+					return
+				}
+				src = derive.NewBlobDataSource(ctx, a.logger, a.dsConfig, a.l1Fetcher, a.blobsFetcher, ref, a.rollupCfg.BatchInboxAddress)
+			} else {
+				src = derive.NewCalldataSource(ctx, a.logger, a.dsConfig, a.l1Fetcher, ref, a.rollupCfg.BatchInboxAddress)
+			}
+			src = derive.NewPlasmaDataSource(a.logger, src, a.l1Fetcher, a.plasmaFetcher, ref)
+
+			if err := a.plasmaFetcher.AdvanceL1Origin(ctx, a.l1Fetcher, ref.ID()); err != nil {
+				if !errors.Is(err, plasma.ErrReorgRequired) {
+					a.logger.Error("failed to advance plasma L1 origin: ", err)
+					return
+				}
+			}
+			for {
+				// the l1 source returns the input commitment for the batch.
+				data, err := src.Next(ctx)
+				if err == io.EOF {
+					// no (more) commitments to process for this block ref, break the loop
+					break
+				} else if err != nil {
+					// critical failure upstream
+					a.logger.Error("failed to return input commitment for batch: ", err)
+					// TODO return this error
+					return
+				}
+
+				if len(data) == 0 {
+					// critical failure upstream if we were returned no data without an io.EOF error
+					a.logger.Error(derive.NotEnoughData.Error())
+					// TODO: return this error
+					return
+				}
+
+				// If the tx data type is not plasma, we skip it
+				if data[0] != plasma.TxDataVersion1 {
+					continue
+				}
+
+				// validate batcher inbox data is a commitment.
+				// strip the transaction data version byte from the data before decoding.
+				comm, err := plasma.DecodeCommitmentData(data[1:])
+				if err != nil {
+					// invalid commitment, don't need to do anything with it
+					a.logger.Warn("invalid commitment", "commitment", data, "err", err)
+					continue
+				}
+
+				// use the commitment to fetch the input from the plasma DA provider.
+				daData, err := a.plasmaFetcher.GetInput(ctx, a.l1Fetcher, comm, ref)
+				switch {
+				case errors.Is(err, plasma.ErrActiveChallenge):
+					// we were unable to fetch the data but there is already an active challenge, do nothing
+					// separating this from the default because in the future we may want to handle this case by
+					// periodically trying to fetch the missing data and resolve the challenge
+				case errors.Is(err, plasma.ErrPendingChallenge):
+					// TODO: consider also handling retry logic for the entire challenge_window
+					// if we were unable to fetch the data but there is no active challenge, then we should create one
+					if a.challenger != nil {
+						a.logger.Info("challenging altDA commitment with missing data",
+							"commitment height", ref.Number,
+							"commitment", comm.Encode())
+						if err := a.challenger.Schedule(ref.Number, types.CommitmentArg{
+							ChallengedBlockNumber: new(big.Int).SetUint64(ref.Number),
+							ChallengedCommitment:  comm.Encode(),
+						}); err != nil {
+							// TODO: better error handling e.g. we need to retry
+							a.logger.Error(err.Error())
+						}
+						a.metrics.RecordLastActedL1Block(ref.Number)
+						a.metrics.RecordActedL1Ref(ref)
+					}
+				case errors.Is(err, nil):
+					// if we were able to fetch the data but there is an active challenge, then we should resolve it
+					status := a.plasmaFetcher.GetChallengeStatus(comm, ref.Number)
+					if status == plasma.ChallengeActive {
+						a.logger.Info("resolving altDA commitment with retrieved data",
+							"commitment height", ref.Number,
+							"commitment", comm.Encode())
+						if err := a.resolver.Schedule(ref.Number, types.ResolveData{
+							CommitmentArg: types.CommitmentArg{
+								ChallengedBlockNumber: new(big.Int).SetUint64(ref.Number),
+								ChallengedCommitment:  comm.Encode(),
+							},
+							Blob: daData,
+						}); err != nil {
+							// TODO: better error handling e.g. we need to retry
+							a.logger.Error(err.Error())
+						}
+						a.metrics.RecordLastActedL1Block(ref.Number)
+						a.metrics.RecordActedL1Ref(ref)
+					}
+				default:
+					// other cases where there is nothing to do: ErrPendingChallenge, ErrExpiredChallenge, ErrMissingPastWindow.
+				}
+			}
+		}
+	}
+}
+
+func (a *Actor) Close() error {
+	a.cancel()
+	a.wg.Wait()
+	return nil
+}

--- a/op-dachallenger/challenge/keccak256/contract_creator.go
+++ b/op-dachallenger/challenge/keccak256/contract_creator.go
@@ -1,0 +1,33 @@
+package keccak256
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/keccak256/contracts"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type ContractCreator struct{}
+
+func (c *ContractCreator) ChallengeContractCreator(ctx context.Context, m metrics.ContractMetricer,
+	addr common.Address, caller *batching.MultiCaller) (types.ChallengeContract, error) {
+	return contracts.NewDAChallengeContract(ctx, m, addr, caller)
+}
+
+func (c *ContractCreator) WithdrawContractCreator(ctx context.Context, m metrics.ContractMetricer,
+	addr common.Address, caller *batching.MultiCaller) (types.WithdrawContract, error) {
+	return contracts.NewDAChallengeContract(ctx, m, addr, caller)
+}
+
+func (c *ContractCreator) ResolveContractCreator(ctx context.Context, m metrics.ContractMetricer,
+	addr common.Address, caller *batching.MultiCaller) (types.ResolveContract, error) {
+	return contracts.NewDAChallengeContract(ctx, m, addr, caller)
+}
+
+func (c *ContractCreator) UnlockContractCreator(ctx context.Context, m metrics.ContractMetricer,
+	addr common.Address, caller *batching.MultiCaller) (types.UnlockContract, error) {
+	return contracts.NewDAChallengeContract(ctx, m, addr, caller)
+}

--- a/op-dachallenger/challenge/keccak256/contracts/dachallenge.go
+++ b/op-dachallenger/challenge/keccak256/contracts/dachallenge.go
@@ -1,0 +1,215 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	methodVersion                    = "version"
+	methodChallengeWindow            = "challengeWindow"
+	methodResolveWindow              = "resolveWindow"
+	methodBondSize                   = "bondSize"
+	methodBalances                   = "balances"
+	methodDeposit                    = "deposit"
+	methodWithdraw                   = "withdraw"
+	methodGetChallenge               = "getChallenge"
+	methodGetChallengeStatus         = "getChallengeStatus"
+	methodValidateCommitment         = "validateCommitment"
+	methodChallenge                  = "challenge"
+	methodResolve                    = "resolve"
+	methodUnlockBond                 = "unlockBond"
+	methodComputeCommitmentKeccak256 = "computeCommitmentKeccak256"
+)
+
+type DAChallengeContract interface {
+	GetChallengeWindow(ctx context.Context) (*big.Int, error)
+	GetResolveWindow(ctx context.Context) (*big.Int, error)
+	GetBondSize(ctx context.Context) (*big.Int, error)
+	GetChallenge(ctx context.Context, challenge types.CommitmentArg) (*types.Challenge, error)
+	GetChallengeStatus(ctx context.Context, challenge types.CommitmentArg) (types.ChallengeStatus, error)
+	GetBalance(ctx context.Context, addr common.Address) (*big.Int, error)
+	Deposit(ctx context.Context) (txmgr.TxCandidate, error)
+	Challenge(ctx context.Context, challenge types.CommitmentArg) (txmgr.TxCandidate, error)
+	UnlockBond(ctx context.Context, challenge types.CommitmentArg) (txmgr.TxCandidate, error)
+	Withdraw(ctx context.Context) (txmgr.TxCandidate, error)
+	ValidateCommitment(ctx context.Context, commitment []byte) (bool, error)
+	ComputeCommitmentKeccak256(ctx context.Context, blob []byte) ([]byte, error)
+	Resolve(ctx context.Context, challenge types.CommitmentArg, blob []byte) (txmgr.TxCandidate, error)
+}
+
+var _ DAChallengeContract = &DAChallengeContractLatest{}
+
+type DAChallengeContractLatest struct {
+	metrics     metrics.ContractMetricer
+	multiCaller *batching.MultiCaller
+	contract    *batching.BoundContract
+	abi         *abi.ABI
+}
+
+type challenge struct {
+	Challenger    [32]byte
+	LockedBond    [32]byte
+	StartBlock    [32]byte
+	ResolvedBlock [32]byte
+}
+
+func NewDAChallengeContract(ctx context.Context, m metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (DAChallengeContract, error) {
+	contractAbi := snapshots.LoadDAChallengeABI()
+
+	result, err := caller.SingleCall(ctx, rpcblock.Latest, batching.NewContractCall(contractAbi, addr, methodVersion))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve version of dispute game %v: %w", addr, err)
+	}
+	version := result.GetString(0)
+	supportedVersion := "1.0.0"
+	if version != supportedVersion {
+		return nil, fmt.Errorf("unrecognized version for dachallenge contract %s, expected %s", version, supportedVersion)
+	} else {
+		return &DAChallengeContractLatest{
+			metrics:     m,
+			multiCaller: caller,
+			contract:    batching.NewBoundContract(contractAbi, addr),
+			abi:         contractAbi,
+		}, nil
+	}
+}
+
+func (d *DAChallengeContractLatest) GetChallengeWindow(ctx context.Context) (*big.Int, error) {
+	defer d.metrics.StartContractRequest("GetChallengeWindow")()
+	res, err := d.multiCaller.SingleCall(ctx, rpcblock.Latest, d.contract.Call(methodChallengeWindow))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve challenge window: %w", err)
+	}
+	return res.GetBigInt(0), nil
+}
+
+func (d *DAChallengeContractLatest) GetResolveWindow(ctx context.Context) (*big.Int, error) {
+	defer d.metrics.StartContractRequest("GetResolveWindow")()
+	res, err := d.multiCaller.SingleCall(ctx, rpcblock.Latest, d.contract.Call(methodResolveWindow))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve the resolve window: %w", err)
+	}
+	return res.GetBigInt(0), nil
+}
+
+func (d *DAChallengeContractLatest) GetBondSize(ctx context.Context) (*big.Int, error) {
+	defer d.metrics.StartContractRequest("GetBondSize")()
+	res, err := d.multiCaller.SingleCall(ctx, rpcblock.Latest, d.contract.Call(methodBondSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve the bond size: %w", err)
+	}
+	return res.GetBigInt(0), nil
+}
+
+func (d *DAChallengeContractLatest) GetChallenge(ctx context.Context, challenge types.CommitmentArg) (*types.Challenge, error) {
+	defer d.metrics.StartContractRequest("GetChallenge")()
+	res, err := d.multiCaller.SingleCall(ctx, rpcblock.Latest, d.contract.Call(methodGetChallenge,
+		common.BigToHash(challenge.ChallengedBlockNumber).Bytes(), challenge.ChallengedCommitment))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve the challenge: %w", err)
+	}
+	return &types.Challenge{
+		CommitmentArg: challenge,
+		Challenger:    res.GetAddress(0),
+		LockedBond:    res.GetBigInt(1),
+		StartBlock:    res.GetBigInt(2),
+		ResolvedBlock: res.GetBigInt(3),
+	}, nil
+}
+
+func (d *DAChallengeContractLatest) GetChallengeStatus(ctx context.Context, challenge types.CommitmentArg) (types.ChallengeStatus, error) {
+	defer d.metrics.StartContractRequest("GetChallengeStatus")
+	res, err := d.multiCaller.SingleCall(ctx, rpcblock.Latest, d.contract.Call(methodGetChallengeStatus,
+		common.BigToHash(challenge.ChallengedBlockNumber).Bytes(), challenge.ChallengedCommitment))
+	if err != nil {
+		return 0, fmt.Errorf("failed to retrieve the challenge status: %w", err)
+	}
+	return types.ChallengeStatus(res.GetUint64(0)), nil
+}
+
+func (d *DAChallengeContractLatest) GetBalance(ctx context.Context, addr common.Address) (*big.Int, error) {
+	defer d.metrics.StartContractRequest("GetBalance")
+	res, err := d.multiCaller.SingleCall(ctx, rpcblock.Latest, d.contract.Call(methodBalances,
+		addr.Bytes()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve the balance: %w", err)
+	}
+	return res.GetBigInt(0), nil
+}
+
+func (d *DAChallengeContractLatest) Deposit(ctx context.Context) (txmgr.TxCandidate, error) {
+	defer d.metrics.StartContractRequest("Deposit")
+	tx, err := d.contract.Call(methodDeposit).ToTxCandidate()
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("failed to create deposit tx: %w", err)
+	}
+	return tx, nil
+}
+
+func (d *DAChallengeContractLatest) Challenge(ctx context.Context, challenge types.CommitmentArg) (txmgr.TxCandidate, error) {
+	defer d.metrics.StartContractRequest("Challenge")
+	tx, err := d.contract.Call(methodChallenge, common.BigToHash(challenge.ChallengedBlockNumber).Bytes(),
+		challenge.ChallengedCommitment).ToTxCandidate()
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("failed to create challenge tx: %w", err)
+	}
+	return tx, nil
+}
+
+func (d *DAChallengeContractLatest) UnlockBond(ctx context.Context, challenge types.CommitmentArg) (txmgr.TxCandidate, error) {
+	defer d.metrics.StartContractRequest("UnlockBond")
+	tx, err := d.contract.Call(methodUnlockBond, common.BigToHash(challenge.ChallengedBlockNumber).Bytes(),
+		challenge.ChallengedCommitment).ToTxCandidate()
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("failed to create unlock bond tx: %w", err)
+	}
+	return tx, nil
+}
+
+func (d *DAChallengeContractLatest) Withdraw(ctx context.Context) (txmgr.TxCandidate, error) {
+	defer d.metrics.StartContractRequest("Withdraw")
+	tx, err := d.contract.Call(methodWithdraw).ToTxCandidate()
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("failed to create withdraw tx: %w", err)
+	}
+	return tx, nil
+}
+
+func (d *DAChallengeContractLatest) ValidateCommitment(ctx context.Context, commitment []byte) (bool, error) {
+	defer d.metrics.StartContractRequest("ValidateCommitment")
+	_, err := d.multiCaller.SingleCall(ctx, rpcblock.Latest, d.contract.Call(methodValidateCommitment, commitment))
+	if err != nil {
+		return false, fmt.Errorf("failed to validate commitment: %w", err)
+	}
+	return true, nil
+}
+
+func (d *DAChallengeContractLatest) ComputeCommitmentKeccak256(ctx context.Context, blob []byte) ([]byte, error) {
+	defer d.metrics.StartContractRequest("ComputeCommitmentKeccak256")
+	res, err := d.multiCaller.SingleCall(ctx, rpcblock.Latest, d.contract.Call(methodComputeCommitmentKeccak256, blob))
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute commitment keccak256: %w", err)
+	}
+	return res.GetBytes(0), nil
+}
+
+func (d *DAChallengeContractLatest) Resolve(ctx context.Context, challenge types.CommitmentArg, blob []byte) (txmgr.TxCandidate, error) {
+	defer d.metrics.StartContractRequest("Resolve")
+	tx, err := d.contract.Call(methodResolve, common.BigToHash(challenge.ChallengedBlockNumber).Bytes(),
+		challenge.ChallengedCommitment, blob).ToTxCandidate()
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("failed to create withdraw tx: %w", err)
+	}
+	return tx, nil
+}

--- a/op-dachallenger/challenge/keccak256/contracts/dachallenge_test.go
+++ b/op-dachallenger/challenge/keccak256/contracts/dachallenge_test.go
@@ -1,0 +1,321 @@
+package contracts
+
+import (
+	"context"
+	"math/big"
+	"math/rand"
+	"slices"
+	"testing"
+
+	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	plasma "github.com/ethereum-optimism/optimism/op-plasma"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dacAddr        = common.HexToAddress("0x24112842371dFC380576ebb09Ae16Cb6B6caD7CB")
+	balAddr        = common.HexToAddress("0x33332842371dFC380576ebb09Ae16Cb6B6c3333")
+	challengerAddr = common.HexToAddress("0x44442842371dFC380576ebb09Ae16Cb6B6ca4444")
+)
+
+type contractVersion struct {
+	version string
+	loadAbi func() *abi.ABI
+}
+
+func (c contractVersion) Is(versions ...string) bool {
+	return slices.Contains(versions, c.version)
+}
+
+const (
+	versLatest = "1.0.0"
+)
+
+var (
+	seed               int64 = 1337
+	rnd                      = rand.New(rand.NewSource(seed))
+	challengeWindow          = big.NewInt(1337)
+	resolveWindow            = big.NewInt(1773)
+	bondSize                 = big.NewInt(1373)
+	balance                  = big.NewInt(7331)
+	lockedBond               = big.NewInt(3000)
+	startBlock               = big.NewInt(20000000)
+	resolvedBlock            = big.NewInt(20010000)
+	status                   = types.Resolved
+	blob                     = make([]byte, 32*4096)
+	_, _                     = rnd.Read(blob)
+	challengeHeight          = big.NewInt(19999999)
+	commitment               = crypto.Keccak256(blob)
+	prefixedCommitment       = append([]byte{uint8(plasma.Keccak256CommitmentType)}, commitment...)
+	comm                     = types.CommitmentArg{
+		ChallengedBlockNumber: challengeHeight,
+		ChallengedCommitment:  prefixedCommitment,
+	}
+	chal = &types.Challenge{
+		CommitmentArg: comm,
+		Challenger:    challengerAddr,
+		LockedBond:    lockedBond,
+		StartBlock:    startBlock,
+		ResolvedBlock: resolvedBlock,
+	}
+)
+
+var versions = []contractVersion{
+	{
+		version: versLatest,
+		loadAbi: snapshots.LoadDAChallengeABI,
+	},
+}
+
+func TestSimpleGetters(t *testing.T) {
+	tests := []struct {
+		methodAlias string
+		method      string
+		args        []interface{}
+		result      interface{}
+		expected    interface{} // Defaults to expecting the same as result
+		call        func(game DAChallengeContract) (any, error)
+		applies     func(version contractVersion) bool
+	}{
+		{
+			methodAlias: "challengeWindow",
+			method:      methodChallengeWindow,
+			result:      uint64(1337),
+			expected:    challengeWindow,
+			call: func(game DAChallengeContract) (any, error) {
+				return game.GetChallengeWindow(context.Background())
+			},
+		},
+		{
+			methodAlias: "resolveWindow",
+			method:      methodResolveWindow,
+			result:      uint64(1773),
+			expected:    resolveWindow,
+			call: func(game DAChallengeContract) (any, error) {
+				return game.GetResolveWindow(context.Background())
+			},
+		},
+		{
+			methodAlias: "bondSize",
+			method:      methodBondSize,
+			result:      uint64(1373),
+			expected:    bondSize,
+			call: func(game DAChallengeContract) (any, error) {
+				return game.GetBondSize(context.Background())
+			},
+		},
+		{
+			methodAlias: "balances",
+			method:      methodBalances,
+			result:      uint64(7331),
+			expected:    balance,
+			call: func(game DAChallengeContract) (any, error) {
+				return game.GetBalance(context.Background(), balAddr)
+			},
+		},
+		{
+			methodAlias: "getChallenge",
+			method:      methodGetChallenge,
+			result:      chal,
+			expected:    chal,
+			call: func(game DAChallengeContract) (any, error) {
+				return game.GetChallenge(context.Background(), comm)
+			},
+		},
+		{
+			methodAlias: "getChallengeStatus",
+			method:      methodGetChallengeStatus,
+			result:      types.Resolved,
+			expected:    status,
+			call: func(game DAChallengeContract) (any, error) {
+				return game.GetChallengeStatus(context.Background(), comm)
+			},
+		},
+	}
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			for _, test := range tests {
+				test := test
+				t.Run(test.methodAlias, func(t *testing.T) {
+					if test.applies != nil && !test.applies(version) {
+						t.Skip("Skipping for this version")
+					}
+					stubRpc, game := setupDAChallengeTest(t, version)
+					stubRpc.SetResponse(dacAddr, test.method, rpcblock.Latest, nil, []interface{}{test.result})
+					status, err := test.call(game)
+					require.NoError(t, err)
+					expected := test.expected
+					if expected == nil {
+						expected = test.result
+					}
+					require.Equal(t, expected, status)
+				})
+			}
+		})
+	}
+}
+
+func TestGetBalance(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, dac := setupDAChallengeTest(t, version)
+			stubRpc.SetResponse(dacAddr, methodBalances, rpcblock.Latest, []interface{}{balAddr.Bytes()}, []interface{}{balance})
+
+			actual, err := dac.GetBalance(context.Background(), balAddr)
+			require.NoError(t, err)
+			require.Equal(t, balance.Bytes(), actual.Bytes())
+		})
+	}
+}
+
+func TestGetChallenge(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, dac := setupDAChallengeTest(t, version)
+			stubRpc.SetResponse(dacAddr, methodGetChallenge, rpcblock.Latest,
+				[]interface{}{common.BigToHash(comm.ChallengedBlockNumber).Bytes(), comm.ChallengedCommitment},
+				[]interface{}{chal.Challenger, chal.LockedBond, chal.StartBlock, chal.ResolvedBlock})
+
+			actual, err := dac.GetChallenge(context.Background(), comm)
+			require.NoError(t, err)
+			require.Equal(t, chal.ChallengedCommitment, chal)
+			require.Equal(t, chal.Challenger, actual.Challenger)
+			require.Equal(t, chal.LockedBond, actual.LockedBond)
+			require.Equal(t, chal.StartBlock, actual.StartBlock)
+			require.Equal(t, chal.ResolvedBlock, actual.ResolvedBlock)
+		})
+	}
+}
+
+func TestGetChallengeStatus(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, game := setupDAChallengeTest(t, version)
+			stubRpc.SetResponse(dacAddr, methodGetChallengeStatus, rpcblock.Latest,
+				[]interface{}{common.BigToHash(comm.ChallengedBlockNumber).Bytes(), comm.ChallengedCommitment},
+				[]interface{}{status.ToUint64()})
+			actual, err := game.GetChallengeStatus(context.Background(), comm)
+			require.NoError(t, err)
+			require.Equal(t, status, actual)
+		})
+	}
+}
+
+func TestValidateCommitment(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, game := setupDAChallengeTest(t, version)
+			stubRpc.SetResponse(dacAddr, methodWithdraw, rpcblock.Latest, []interface{}{prefixedCommitment}, nil)
+			actual, err := game.ValidateCommitment(context.Background(), prefixedCommitment)
+			require.NoError(t, err)
+			require.True(t, actual)
+		})
+	}
+}
+
+func TestComputeCommitmentKeccak256(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, game := setupDAChallengeTest(t, version)
+			stubRpc.SetResponse(dacAddr, methodComputeCommitmentKeccak256, rpcblock.Latest, []interface{}{blob},
+				[]interface{}{prefixedCommitment})
+			actual, err := game.ComputeCommitmentKeccak256(context.Background(), blob)
+			require.NoError(t, err)
+			require.Equal(t, prefixedCommitment, actual)
+		})
+	}
+}
+
+func TestDepositTx(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, game := setupDAChallengeTest(t, version)
+			stubRpc.SetResponse(dacAddr, methodDeposit, rpcblock.Latest, nil, nil)
+			tx, err := game.Deposit(context.Background())
+			require.NoError(t, err)
+			stubRpc.VerifyTxCandidate(tx)
+		})
+	}
+}
+
+func TestWithdrawTx(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, game := setupDAChallengeTest(t, version)
+			stubRpc.SetResponse(dacAddr, methodWithdraw, rpcblock.Latest, nil, nil)
+			tx, err := game.Withdraw(context.Background())
+			require.NoError(t, err)
+			stubRpc.VerifyTxCandidate(tx)
+		})
+	}
+}
+
+func TestUnlockBondTx(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, game := setupDAChallengeTest(t, version)
+			stubRpc.SetResponse(dacAddr, methodUnlockBond, rpcblock.Latest, []interface{}{common.BigToHash(comm.ChallengedBlockNumber).Bytes(),
+				comm.ChallengedCommitment}, nil)
+			tx, err := game.UnlockBond(context.Background(), comm)
+			require.NoError(t, err)
+			stubRpc.VerifyTxCandidate(tx)
+		})
+	}
+}
+
+func TestChallengeTx(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, game := setupDAChallengeTest(t, version)
+			stubRpc.SetResponse(dacAddr, methodChallenge, rpcblock.Latest, []interface{}{common.BigToHash(comm.ChallengedBlockNumber).Bytes(),
+				comm.ChallengedCommitment}, nil)
+			tx, err := game.Challenge(context.Background(), comm)
+			require.NoError(t, err)
+			stubRpc.VerifyTxCandidate(tx)
+		})
+	}
+}
+
+func TestResolveTx(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, game := setupDAChallengeTest(t, version)
+			stubRpc.SetResponse(dacAddr, methodResolve, rpcblock.Latest, []interface{}{common.BigToHash(comm.ChallengedBlockNumber).Bytes(),
+				comm.ChallengedCommitment, blob}, nil)
+			tx, err := game.Resolve(context.Background(), comm, blob)
+			require.NoError(t, err)
+			stubRpc.VerifyTxCandidate(tx)
+		})
+	}
+}
+
+func setupDAChallengeTest(t *testing.T, version contractVersion) (*batchingTest.AbiBasedRpc, DAChallengeContract) {
+	dacABI := version.loadAbi()
+
+	stubRpc := batchingTest.NewAbiBasedRpc(t, dacAddr, dacABI)
+	caller := batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize)
+
+	stubRpc.SetResponse(dacAddr, methodVersion, rpcblock.Latest, nil, []interface{}{version.version})
+	game, err := NewDAChallengeContract(context.Background(), contractMetrics.NoopContractMetrics, dacAddr, caller)
+	require.NoError(t, err)
+	return stubRpc, game
+}

--- a/op-dachallenger/challenge/register.go
+++ b/op-dachallenger/challenge/register.go
@@ -1,0 +1,89 @@
+package challenge
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/keccak256"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/scheduler"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	daconfig "github.com/ethereum-optimism/optimism/op-dachallenger/config"
+	plasma "github.com/ethereum-optimism/optimism/op-plasma"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/go-errors/errors"
+)
+
+type ContractCreation interface {
+	ChallengeContractCreator(ctx context.Context, m metrics.ContractMetricer,
+		addr common.Address, caller *batching.MultiCaller) (types.ChallengeContract, error)
+	WithdrawContractCreator(ctx context.Context, m metrics.ContractMetricer,
+		addr common.Address, caller *batching.MultiCaller) (types.WithdrawContract, error)
+	ResolveContractCreator(ctx context.Context, m metrics.ContractMetricer,
+		addr common.Address, caller *batching.MultiCaller) (types.ResolveContract, error)
+	UnlockContractCreator(ctx context.Context, m metrics.ContractMetricer,
+		addr common.Address, caller *batching.MultiCaller) (types.UnlockContract, error)
+}
+
+func NewContractCreator(daType plasma.CommitmentType, daKind daconfig.CommitmentKind) (ContractCreation, error) {
+	switch daType {
+	case plasma.Keccak256CommitmentType:
+		return &keccak256.ContractCreator{}, nil
+	case plasma.GenericCommitmentType:
+		switch daKind {
+		case daconfig.Undefined:
+			return nil, errors.New("daKind is undefined")
+		case daconfig.EigenDA:
+			return nil, errors.New("daKind EigenDA is currently unsupported")
+		default:
+			return nil, fmt.Errorf("unrecongized daKind: %d", daKind)
+		}
+	default:
+		return nil, fmt.Errorf("unrecongized daType: %d", daType)
+	}
+}
+
+type Registration interface {
+	RegisterBondWithdrawContract(daType plasma.CommitmentType, daKind daconfig.CommitmentKind,
+		creator scheduler.WithdrawContractCreator)
+	RegisterCommitmentChallengeContract(daType plasma.CommitmentType, daKind daconfig.CommitmentKind,
+		creator scheduler.ChallengeContractCreator)
+	RegisterBondUnlockContract(daType plasma.CommitmentType, daKind daconfig.CommitmentKind,
+		creator scheduler.UnlockerContractCreator)
+	RegisterChallengeResolverContract(daType plasma.CommitmentType, daKind daconfig.CommitmentKind,
+		creator scheduler.ResolveContractCreator)
+}
+
+var _ Registration = &Registry{}
+
+type Registry struct {
+	CreateChallengeContract map[plasma.CommitmentType]map[daconfig.CommitmentKind]func(ctx context.Context,
+		m metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (types.ChallengeContract, error)
+	CreateUnlockContract map[plasma.CommitmentType]map[daconfig.CommitmentKind]func(ctx context.Context,
+		m metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (types.UnlockContract, error)
+	CreateWithdrawContract map[plasma.CommitmentType]map[daconfig.CommitmentKind]func(ctx context.Context,
+		m metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (types.WithdrawContract, error)
+	CreateResolveContract map[plasma.CommitmentType]map[daconfig.CommitmentKind]func(ctx context.Context,
+		m metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (types.ResolveContract, error)
+}
+
+func (r *Registry) RegisterBondWithdrawContract(daType plasma.CommitmentType, daKind daconfig.CommitmentKind,
+	creator scheduler.WithdrawContractCreator) {
+	r.CreateWithdrawContract[daType][daKind] = creator
+}
+
+func (r *Registry) RegisterCommitmentChallengeContract(daType plasma.CommitmentType, daKind daconfig.CommitmentKind,
+	creator scheduler.ChallengeContractCreator) {
+	r.CreateChallengeContract[daType][daKind] = creator
+}
+
+func (r *Registry) RegisterBondUnlockContract(daType plasma.CommitmentType, daKind daconfig.CommitmentKind,
+	creator scheduler.UnlockerContractCreator) {
+	r.CreateUnlockContract[daType][daKind] = creator
+}
+
+func (r *Registry) RegisterChallengeResolverContract(daType plasma.CommitmentType, daKind daconfig.CommitmentKind,
+	creator scheduler.ResolveContractCreator) {
+	r.CreateResolveContract[daType][daKind] = creator
+}

--- a/op-dachallenger/challenge/scheduler/challenger.go
+++ b/op-dachallenger/challenge/scheduler/challenger.go
@@ -1,0 +1,47 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type ChallengeContractCreator func(ctx context.Context, m metrics.ContractMetricer,
+	addr common.Address, caller *batching.MultiCaller) (types.ChallengeContract, error)
+
+type Challenger struct {
+	logger   log.Logger
+	contract types.ChallengeContract
+	txSender types.TxSender
+}
+
+var _ Challenging = (*Challenger)(nil)
+
+func NewChallenger(l log.Logger, contract types.ChallengeContract, txSender types.TxSender) *Challenger {
+	return &Challenger{
+		logger:   l,
+		contract: contract,
+		txSender: txSender,
+	}
+}
+
+func (c *Challenger) ChallengeCommitment(ctx context.Context, commitment types.CommitmentArg) (err error) {
+	c.logger.Debug("Attempting to challenge commitment for", "blockheight", commitment.ChallengedBlockNumber,
+		"commitment", commitment.ChallengedCommitment)
+
+	candidate, err := c.contract.Challenge(ctx, commitment)
+	if err != nil {
+		return fmt.Errorf("failed to create candidate challenge tx: %w", err)
+	}
+
+	if err = c.txSender.SendAndWaitSimple("challenge da commitment", candidate); err != nil {
+		return fmt.Errorf("failed to challenge da commitment: %w", err)
+	}
+
+	return nil
+}

--- a/op-dachallenger/challenge/scheduler/challenges.go
+++ b/op-dachallenger/challenge/scheduler/challenges.go
@@ -1,0 +1,78 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type Challenging interface {
+	ChallengeCommitment(ctx context.Context, commitment types.CommitmentArg) error
+}
+
+type ChallengeScheduler struct {
+	log        log.Logger
+	metrics    ChallengerSchedulerMetrics
+	ch         chan challengeMessage
+	challenger Challenging
+	cancel     func()
+	wg         sync.WaitGroup
+}
+
+type ChallengerSchedulerMetrics interface {
+	RecordDAChallengeFailed()
+	RecordDAChallenge()
+}
+
+type challengeMessage struct {
+	blockNumber uint64
+	commitment  types.CommitmentArg
+}
+
+func NewChallengeScheduler(logger log.Logger, metrics ChallengerSchedulerMetrics, challenger Challenging) *ChallengeScheduler {
+	return &ChallengeScheduler{
+		log:        logger,
+		metrics:    metrics,
+		ch:         make(chan challengeMessage, 1),
+		challenger: challenger,
+	}
+}
+
+func (s *ChallengeScheduler) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.wg.Add(1)
+	go s.run(ctx)
+}
+
+func (s *ChallengeScheduler) Close() error {
+	s.cancel()
+	s.wg.Wait()
+	return nil
+}
+
+func (s *ChallengeScheduler) run(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-s.ch:
+			if err := s.challenger.ChallengeCommitment(ctx, msg.commitment); err != nil {
+				s.metrics.RecordDAChallengeFailed()
+				s.log.Error("Failed to challenge commitments", "blockNumber", msg.blockNumber, "err", err)
+			} else {
+				s.metrics.RecordDAChallenge()
+			}
+		}
+	}
+}
+
+func (s *ChallengeScheduler) Schedule(blockNumber uint64, commitment types.CommitmentArg) error {
+	select {
+	case s.ch <- challengeMessage{blockNumber, commitment}:
+	}
+	return nil
+}

--- a/op-dachallenger/challenge/scheduler/resolver.go
+++ b/op-dachallenger/challenge/scheduler/resolver.go
@@ -1,0 +1,47 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type ResolveContractCreator func(ctx context.Context, m metrics.ContractMetricer,
+	addr common.Address, caller *batching.MultiCaller) (types.ResolveContract, error)
+
+type Resolver struct {
+	logger   log.Logger
+	contract types.ResolveContract
+	txSender types.TxSender
+}
+
+var _ Resolving = (*Resolver)(nil)
+
+func NewResolver(l log.Logger, contract types.ResolveContract, txSender types.TxSender) *Resolver {
+	return &Resolver{
+		logger:   l,
+		contract: contract,
+		txSender: txSender,
+	}
+}
+
+func (c *Resolver) ResolveChallenge(ctx context.Context, resolveData types.ResolveData) (err error) {
+	c.logger.Debug("Attempting to resolve challenge for", "blockheight", resolveData.ChallengedBlockNumber,
+		"commitment", resolveData.ChallengedCommitment)
+
+	candidate, err := c.contract.Resolve(ctx, resolveData.CommitmentArg, resolveData.Blob)
+	if err != nil {
+		return fmt.Errorf("failed to create candidate resolve tx: %w", err)
+	}
+
+	if err = c.txSender.SendAndWaitSimple("resolve da challenge", candidate); err != nil {
+		return fmt.Errorf("failed to resolve da challenge: %w", err)
+	}
+
+	return nil
+}

--- a/op-dachallenger/challenge/scheduler/resolves.go
+++ b/op-dachallenger/challenge/scheduler/resolves.go
@@ -1,0 +1,78 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type Resolving interface {
+	ResolveChallenge(ctx context.Context, resolveData types.ResolveData) error
+}
+
+type ResolveScheduler struct {
+	log      log.Logger
+	metrics  ResolveSchedulerMetrics
+	ch       chan resolveMessage
+	resolver Resolving
+	cancel   func()
+	wg       sync.WaitGroup
+}
+
+type ResolveSchedulerMetrics interface {
+	RecordDAResolveFailed()
+	RecordDAResolve()
+}
+
+type resolveMessage struct {
+	blockNumber uint64
+	resolveData types.ResolveData
+}
+
+func NewResolveScheduler(logger log.Logger, metrics ResolveSchedulerMetrics, resolver Resolving) *ResolveScheduler {
+	return &ResolveScheduler{
+		log:      logger,
+		metrics:  metrics,
+		ch:       make(chan resolveMessage, 1),
+		resolver: resolver,
+	}
+}
+
+func (s *ResolveScheduler) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.wg.Add(1)
+	go s.run(ctx)
+}
+
+func (s *ResolveScheduler) Close() error {
+	s.cancel()
+	s.wg.Wait()
+	return nil
+}
+
+func (s *ResolveScheduler) run(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-s.ch:
+			if err := s.resolver.ResolveChallenge(ctx, msg.resolveData); err != nil {
+				s.metrics.RecordDAResolveFailed()
+				s.log.Error("Failed to resolve challenges", "blockNumber", msg.blockNumber, "err", err)
+			} else {
+				s.metrics.RecordDAResolve()
+			}
+		}
+	}
+}
+
+func (s *ResolveScheduler) Schedule(blockNumber uint64, resolveData types.ResolveData) error {
+	select {
+	case s.ch <- resolveMessage{blockNumber, resolveData}:
+	}
+	return nil
+}

--- a/op-dachallenger/challenge/scheduler/unlocker.go
+++ b/op-dachallenger/challenge/scheduler/unlocker.go
@@ -1,0 +1,53 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type UnlockerContractCreator func(ctx context.Context, m metrics.ContractMetricer,
+	addr common.Address, caller *batching.MultiCaller) (types.UnlockContract, error)
+
+type Unlocker struct {
+	logger   log.Logger
+	contract types.UnlockContract
+	txSender types.TxSender
+}
+
+var _ BondUnlocker = (*Unlocker)(nil)
+
+func NewBondUnlocker(l log.Logger, contract types.UnlockContract, txSender types.TxSender) *Unlocker {
+	return &Unlocker{
+		logger:   l,
+		contract: contract,
+		txSender: txSender,
+	}
+}
+
+func (c *Unlocker) UnlockBond(ctx context.Context, challenge types.CommitmentArg) (err error) {
+	c.logger.Debug("Attempting to unlock bonds for", "blockheight", challenge.ChallengedBlockNumber,
+		"commitment", challenge.ChallengedCommitment)
+
+	candidate, err := c.contract.UnlockBond(ctx, challenge)
+	if errors.Is(err, contracts.ErrSimulationFailed) {
+		c.logger.Debug("Bond is still locked", "height", challenge.ChallengedBlockNumber,
+			"commitment", challenge.ChallengedCommitment)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to create candidate unlock bond tx: %w", err)
+	}
+
+	if err = c.txSender.SendAndWaitSimple("unlock bond", candidate); err != nil {
+		return fmt.Errorf("failed to unlock bond: %w", err)
+	}
+
+	return nil
+}

--- a/op-dachallenger/challenge/scheduler/unlocks.go
+++ b/op-dachallenger/challenge/scheduler/unlocks.go
@@ -1,0 +1,78 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type BondUnlocker interface {
+	UnlockBond(ctx context.Context, challenge types.CommitmentArg) error
+}
+
+type BondUnlockScheduler struct {
+	log      log.Logger
+	metrics  BondUnlockSchedulerMetrics
+	ch       chan unlockMessage
+	unlocker BondUnlocker
+	cancel   func()
+	wg       sync.WaitGroup
+}
+
+type BondUnlockSchedulerMetrics interface {
+	RecordBondUnlockFailed()
+	RecordBondUnlock()
+}
+
+type unlockMessage struct {
+	blockNumber uint64
+	challenge   types.CommitmentArg
+}
+
+func NewBondUnlockScheduler(logger log.Logger, metrics BondUnlockSchedulerMetrics, unlocker BondUnlocker) *BondUnlockScheduler {
+	return &BondUnlockScheduler{
+		log:      logger,
+		metrics:  metrics,
+		ch:       make(chan unlockMessage, 1),
+		unlocker: unlocker,
+	}
+}
+
+func (s *BondUnlockScheduler) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.wg.Add(1)
+	go s.run(ctx)
+}
+
+func (s *BondUnlockScheduler) Close() error {
+	s.cancel()
+	s.wg.Wait()
+	return nil
+}
+
+func (s *BondUnlockScheduler) run(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-s.ch:
+			if err := s.unlocker.UnlockBond(ctx, msg.challenge); err != nil {
+				s.metrics.RecordBondUnlockFailed()
+				s.log.Error("Failed to claim bonds", "blockNumber", msg.blockNumber, "err", err)
+			}
+		}
+	}
+}
+
+func (s *BondUnlockScheduler) Schedule(blockNumber uint64, challenge types.CommitmentArg) error {
+	select {
+	case s.ch <- unlockMessage{blockNumber, challenge}:
+	default:
+		s.log.Trace("Skipping game bond claim while claiming in progress")
+	}
+	return nil
+}

--- a/op-dachallenger/challenge/scheduler/withdrawer.go
+++ b/op-dachallenger/challenge/scheduler/withdrawer.go
@@ -1,0 +1,46 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type WithdrawContractCreator func(ctx context.Context, m metrics.ContractMetricer,
+	addr common.Address, caller *batching.MultiCaller) (types.WithdrawContract, error)
+
+type Withdrawer struct {
+	logger   log.Logger
+	contract types.WithdrawContract
+	txSender types.TxSender
+}
+
+var _ BondWithdrawer = (*Withdrawer)(nil)
+
+func NewBondWithdrawer(l log.Logger, contract types.WithdrawContract, txSender types.TxSender) *Withdrawer {
+	return &Withdrawer{
+		logger:   l,
+		contract: contract,
+		txSender: txSender,
+	}
+}
+
+func (w *Withdrawer) WithdrawBonds(ctx context.Context, height uint64) (err error) {
+	w.logger.Debug("Attempting to withdraw bonds for", "blockheight", height)
+
+	candidate, err := w.contract.Withdraw(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create candidate withdraw tx: %w", err)
+	}
+
+	if err = w.txSender.SendAndWaitSimple("withdraw bonds", candidate); err != nil {
+		return fmt.Errorf("failed to withdraw bonds: %w", err)
+	}
+
+	return nil
+}

--- a/op-dachallenger/challenge/scheduler/withdraws.go
+++ b/op-dachallenger/challenge/scheduler/withdraws.go
@@ -1,0 +1,76 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type BondWithdrawer interface {
+	WithdrawBonds(ctx context.Context, height uint64) (err error)
+}
+
+type WithdrawScheduler struct {
+	log        log.Logger
+	metrics    WithdrawSchedulerMetrics
+	ch         chan withdrawMessage
+	withdrawer BondWithdrawer
+	cancel     func()
+	wg         sync.WaitGroup
+}
+
+type WithdrawSchedulerMetrics interface {
+	RecordWithdrawFailed()
+	RecordWithdraw()
+}
+
+type withdrawMessage struct {
+	blockNumber uint64
+}
+
+func NewWithdrawScheduler(logger log.Logger, metrics WithdrawSchedulerMetrics, withdrawer BondWithdrawer) *WithdrawScheduler {
+	return &WithdrawScheduler{
+		log:        logger,
+		metrics:    metrics,
+		ch:         make(chan withdrawMessage, 1),
+		withdrawer: withdrawer,
+	}
+}
+
+func (s *WithdrawScheduler) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.wg.Add(1)
+	go s.run(ctx)
+}
+
+func (s *WithdrawScheduler) Close() error {
+	s.cancel()
+	s.wg.Wait()
+	return nil
+}
+
+func (s *WithdrawScheduler) run(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-s.ch:
+			if err := s.withdrawer.WithdrawBonds(ctx, msg.blockNumber); err != nil {
+				s.metrics.RecordWithdrawFailed()
+				s.log.Error("Failed to claim bonds", "blockNumber", msg.blockNumber, "err", err)
+			}
+		}
+	}
+}
+
+func (s *WithdrawScheduler) Schedule(blockNumber uint64) error {
+	select {
+	case s.ch <- withdrawMessage{blockNumber}:
+	default:
+		s.log.Trace("Skipping game bond claim while claiming in progress")
+	}
+	return nil
+}

--- a/op-dachallenger/challenge/types/interfaces.go
+++ b/op-dachallenger/challenge/types/interfaces.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"context"
+	"io"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	plasma "github.com/ethereum-optimism/optimism/op-plasma"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+)
+
+type PlasmaFetcher interface {
+	derive.PlasmaInputFetcher
+	GetChallengeStatus(comm plasma.CommitmentData, commBlockNumber uint64) plasma.ChallengeStatus
+}
+
+type TxSender interface {
+	SendAndWaitSimple(txPurpose string, txs ...txmgr.TxCandidate) error
+}
+
+type Actor interface {
+	OnNewL1Finalized(ctx context.Context, finalized eth.L1BlockRef)
+	Start(ctx context.Context)
+	io.Closer
+}
+
+type ChallengeContract interface {
+	Challenge(ctx context.Context, challenge CommitmentArg) (txmgr.TxCandidate, error)
+}
+
+type ResolveContract interface {
+	Resolve(ctx context.Context, challenge CommitmentArg, blob []byte) (txmgr.TxCandidate, error)
+}
+
+type UnlockContract interface {
+	UnlockBond(ctx context.Context, challenge CommitmentArg) (txmgr.TxCandidate, error)
+}
+
+type WithdrawContract interface {
+	Withdraw(ctx context.Context) (txmgr.TxCandidate, error)
+}

--- a/op-dachallenger/challenge/types/types.go
+++ b/op-dachallenger/challenge/types/types.go
@@ -1,0 +1,43 @@
+package types
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type ChallengeStatus uint64
+
+const (
+	Uninitialized ChallengeStatus = iota
+	Active
+	Resolved
+	Expired
+)
+
+func (cs ChallengeStatus) ToUint64() uint64 {
+	return uint64(cs)
+}
+
+type CommitmentArg struct {
+	ChallengedBlockNumber *big.Int
+	ChallengedCommitment  []byte
+}
+
+type Challenge struct {
+	CommitmentArg
+	Challenger    common.Address
+	LockedBond    *big.Int
+	StartBlock    *big.Int
+	ResolvedBlock *big.Int
+}
+
+type ResolveData struct {
+	CommitmentArg
+	Blob []byte
+}
+
+type Status struct {
+	CommitmentArg
+	Status ChallengeStatus
+}

--- a/op-dachallenger/challenger.go
+++ b/op-dachallenger/challenger.go
@@ -1,0 +1,19 @@
+package op_dachallenger
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-dachallenger/config"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+)
+
+// Main is the programmatic entry-point for running op-challenger with a given configuration.
+func Main(ctx context.Context, logger log.Logger, cfg *config.Config, m metrics.Metricer) (cliapp.Lifecycle, error) {
+	if err := cfg.Check(); err != nil {
+		return nil, err
+	}
+	return NewService(ctx, logger, cfg, m)
+}

--- a/op-dachallenger/cmd/main.go
+++ b/op-dachallenger/cmd/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/version"
+	op_dachallenger "github.com/ethereum-optimism/optimism/op-dachallenger"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/config"
+	daFlags "github.com/ethereum-optimism/optimism/op-dachallenger/flags"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/metrics"
+	opnode "github.com/ethereum-optimism/optimism/op-node"
+	"github.com/ethereum-optimism/optimism/op-node/flags"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	GitCommit = ""
+	GitDate   = ""
+)
+
+// VersionWithMeta holds the textual version string including the metadata.
+var VersionWithMeta = opservice.FormatVersion(version.Version, GitCommit, GitDate, version.Meta)
+
+func main() {
+	oplog.SetupDefaults()
+
+	app := cli.NewApp()
+	app.Version = VersionWithMeta
+	app.Flags = cliapp.ProtectFlags(append(flags.Flags, daFlags.Flags...))
+	app.Name = "op-dachallenger"
+	app.Usage = "Challenge and resolve DA commitments and challenges"
+	app.Description = "Ensures that op-plasma commitments and challenges are correctly challenged and resolved"
+	app.Action = cliapp.LifecycleCmd(DAChallenge)
+	ctx := opio.WithInterruptBlocker(context.Background())
+	err := app.RunContext(ctx, os.Args)
+	if err != nil {
+		log.Crit("Application failed", "message", err)
+	}
+}
+
+func DAChallenge(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
+	if err := daFlags.CheckRequired(ctx); err != nil {
+		log.Crit("missing some required CLI flags", "error", err)
+	}
+	logCfg := oplog.ReadCLIConfig(ctx)
+	l := oplog.NewLogger(oplog.AppOut(ctx), logCfg)
+	handler := oplog.NewLogHandler(oplog.AppOut(ctx), logCfg)
+	oplog.SetGlobalLogHandler(handler)
+	opservice.ValidateEnvVars(daFlags.EnvVarPrefix, daFlags.Flags, l)
+	opservice.ValidateEnvVars(flags.EnvVarPrefix, flags.Flags, l)
+	opservice.WarnOnDeprecatedFlags(ctx, flags.DeprecatedFlags, l)
+	m := metrics.NewMetrics()
+
+	ethRPC := ctx.String("l1")
+	rpcKindStr := ctx.String("l1-rpckind")
+	defend := ctx.Bool("da-defend")
+	challenge := ctx.Bool("da-challenge")
+	daKind := ctx.Uint("commitment-kind")
+
+	cfg, err := opnode.NewConfig(ctx, l)
+	if err != nil {
+		log.Crit("unable to create the rollup node config", "error", err)
+	}
+	cfg.Cancel = closeApp
+	var rpcKind sources.RPCProviderKind
+	if err := rpcKind.Set(rpcKindStr); err != nil {
+		log.Crit("unrecognized rpc kind", "error", err)
+	}
+	l1ClientCfg := sources.L1ClientDefaultConfig(&cfg.Rollup, true, rpcKind)
+	rpCfg, err := cfg.Rollup.GetOPPlasmaConfig()
+	if cfg.Plasma.Enabled && err != nil {
+		log.Crit("failed to get plasma config", "error", err)
+	}
+	daCfg := config.NewConfig(defend, challenge, ethRPC, config.CommitmentKind(daKind), l1ClientCfg, &cfg.Plasma,
+		&rpCfg, &cfg.Rollup, cfg.Beacon)
+
+	daChallengeService, err := op_dachallenger.Main(ctx.Context, l, daCfg, m)
+	if err != nil {
+		log.Crit("failed to create a new da challenge service", "error", err)
+	}
+
+	if err := daChallengeService.Start(ctx.Context); err != nil {
+		log.Crit("failed to start da challenge service", "error", err)
+	}
+
+	return daChallengeService, nil
+}

--- a/op-dachallenger/config/config.go
+++ b/op-dachallenger/config/config.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"errors"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	plasma "github.com/ethereum-optimism/optimism/op-plasma"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+)
+
+var (
+	ErrMissingL1EthRPC         = errors.New("missing l1 eth rpc url")
+	ErrMissingDACommitmentKind = errors.New("missing generic da challenge kind")
+	ErrNoActorMode             = errors.New("service must be configured with at least one actor mode")
+	ErrMissingL1ClientConfig   = errors.New("missing L1ClientConfig")
+	ErrMissingPlasmaConfig     = errors.New("missing PlasmaConfig")
+	ErrMissingPlasmaCLIConfig  = errors.New("missing PlasmaCLIConfig")
+	ErrMissingRollupConfig     = errors.New("missing RollupConfig")
+	ErrMissingBlobSourceConfig = errors.New("missing BlobSourceConfig")
+)
+
+const (
+	DefaultPollInterval = time.Second * 12
+	DefaultMaxPendingTx = 10
+)
+
+type CommitmentKind uint
+
+const (
+	Undefined CommitmentKind = iota
+	EigenDA
+)
+
+// Config is a well typed config that is parsed from the CLI params.
+// This also contains config options for auxiliary services.
+// It is used to initialize the challenger.
+type Config struct {
+	L1EthRpc string
+
+	Defend    bool
+	Challenge bool
+
+	PollInterval time.Duration // Polling interval for latest-block subscription when using an HTTP RPC provider
+
+	MaxPendingTx uint64 // Maximum number of pending transactions (0 == no limit)
+	TxMgrConfig  txmgr.CLIConfig
+
+	MetricsConfig opmetrics.CLIConfig
+	PprofConfig   oppprof.CLIConfig
+
+	CommitmentKind CommitmentKind
+
+	L1ClientConfig   *sources.L1ClientConfig
+	CLIConfig        *plasma.CLIConfig
+	PlasmaConfig     *plasma.Config
+	RollupConfig     *rollup.Config
+	BlobSourceConfig node.L1BeaconEndpointSetup
+}
+
+func NewConfig(
+	defend, challenge bool,
+	l1EthRpc string,
+	commitmentKind CommitmentKind,
+	l1ClientConfig *sources.L1ClientConfig,
+	plasmaCLIConfig *plasma.CLIConfig,
+	plasmaConfig *plasma.Config,
+	rollupConfig *rollup.Config,
+	blobSourceConfig node.L1BeaconEndpointSetup,
+) *Config {
+	return &Config{
+		L1EthRpc: l1EthRpc,
+
+		Defend:    defend,
+		Challenge: challenge,
+
+		PollInterval: DefaultPollInterval,
+
+		MaxPendingTx: DefaultMaxPendingTx,
+		TxMgrConfig:  txmgr.NewCLIConfig(l1EthRpc, txmgr.DefaultChallengerFlagValues),
+
+		MetricsConfig: opmetrics.DefaultCLIConfig(),
+		PprofConfig:   oppprof.DefaultCLIConfig(),
+
+		CommitmentKind: commitmentKind,
+
+		L1ClientConfig:   l1ClientConfig,
+		CLIConfig:        plasmaCLIConfig,
+		PlasmaConfig:     plasmaConfig,
+		RollupConfig:     rollupConfig,
+		BlobSourceConfig: blobSourceConfig,
+	}
+}
+
+func (c Config) Check() error {
+	if !c.Challenge && !c.Defend {
+		return ErrNoActorMode
+	}
+	if c.L1EthRpc == "" {
+		return ErrMissingL1EthRPC
+	}
+	if c.PlasmaConfig.CommitmentType == plasma.GenericCommitmentType {
+		if c.CommitmentKind == Undefined {
+			return ErrMissingDACommitmentKind
+		}
+	}
+	if c.L1ClientConfig == nil {
+		return ErrMissingL1ClientConfig
+	}
+	if c.PollInterval == 0 {
+		c.PollInterval = DefaultPollInterval
+	}
+	if c.PlasmaConfig == nil {
+		return ErrMissingPlasmaConfig
+	}
+	if c.CLIConfig == nil {
+		return ErrMissingPlasmaCLIConfig
+	}
+	if c.RollupConfig == nil {
+		return ErrMissingRollupConfig
+	}
+	if c.BlobSourceConfig == nil {
+		return ErrMissingBlobSourceConfig
+	}
+	if err := c.TxMgrConfig.Check(); err != nil {
+		return err
+	}
+	if err := c.MetricsConfig.Check(); err != nil {
+		return err
+	}
+	if err := c.PprofConfig.Check(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/op-dachallenger/flags/flags.go
+++ b/op-dachallenger/flags/flags.go
@@ -1,0 +1,71 @@
+package flags
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	opflags "github.com/ethereum-optimism/optimism/op-service/flags"
+)
+
+const EnvVarPrefix = "DA_CHALLENGE"
+
+const (
+	DACategory = "1. DA"
+)
+
+func prefixEnvVars(names ...string) []string {
+	envs := make([]string, 0, len(names))
+	for _, name := range names {
+		envs = append(envs, EnvVarPrefix+"_"+name)
+	}
+	return envs
+}
+
+var (
+	DADefend = &cli.BoolFlag{
+		Name:     "da-defend",
+		Usage:    "Turns on DA challenge resolving",
+		Value:    true,
+		EnvVars:  prefixEnvVars("DA_DEFEND"),
+		Category: DACategory,
+	}
+	DAChallenge = &cli.BoolFlag{
+		Name:     "da-challenge",
+		Usage:    "Turns on DA commitment challenging",
+		EnvVars:  prefixEnvVars("DA_CHALLENGE"),
+		Value:    true,
+		Category: DACategory,
+	}
+	CommitmentKind = &cli.UintFlag{
+		Name:     "commitment-kind",
+		Usage:    "Kind of DA commitment",
+		Value:    0,
+		EnvVars:  prefixEnvVars("COMMITMENT_KIND"),
+		Category: DACategory,
+	}
+)
+
+var requiredFlags = []cli.Flag{
+	DADefend,
+	DAChallenge,
+	CommitmentKind,
+}
+
+var optionalFlags = []cli.Flag{}
+
+// Flags contains the list of configuration options available to the binary.
+var Flags []cli.Flag
+
+func init() {
+	Flags = append(requiredFlags, optionalFlags...)
+}
+
+func CheckRequired(ctx *cli.Context) error {
+	for _, f := range requiredFlags {
+		if !ctx.IsSet(f.Names()[0]) {
+			return fmt.Errorf("flag %s is required", f.Names()[0])
+		}
+	}
+	return opflags.CheckRequiredXor(ctx)
+}

--- a/op-dachallenger/metrics/metrics.go
+++ b/op-dachallenger/metrics/metrics.go
@@ -1,0 +1,226 @@
+package metrics
+
+import (
+	"io"
+
+	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/httputil"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
+	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const Namespace = "op_dachallenger"
+
+type Metricer interface {
+	RecordUp()
+	RecordInfo(version string)
+
+	StartBalanceMetrics(l log.Logger, client *ethclient.Client, account common.Address) io.Closer
+
+	// Record Tx metrics
+	txmetrics.TxMetricer
+
+	// Record cache metrics
+	caching.Metrics
+
+	// Record contract metrics
+	contractMetrics.ContractMetricer
+
+	RecordLastActedL1Block(n uint64)
+	RecordActedL1Ref(ref eth.L1BlockRef)
+
+	RecordDAChallenge()
+	RecordDAChallengeFailed()
+	RecordDAResolve()
+	RecordDAResolveFailed()
+	RecordBondUnlock()
+	RecordBondUnlockFailed()
+	RecordWithdraw()
+	RecordWithdrawFailed()
+}
+
+// Metrics implementation must implement RegistryMetricer to allow the metrics server to work.
+var _ opmetrics.RegistryMetricer = (*Metrics)(nil)
+
+type Metrics struct {
+	ns       string
+	registry *prometheus.Registry
+	factory  opmetrics.Factory
+
+	txmetrics.TxMetrics
+	*opmetrics.CacheMetrics
+	*contractMetrics.ContractMetrics
+
+	highestLastActedL1Block prometheus.Gauge
+	recordedL1Ref           prometheus.GaugeVec
+
+	up   prometheus.Counter
+	info prometheus.GaugeVec
+
+	challenges        prometheus.Counter
+	failedChallenges  prometheus.Counter
+	resolutions       prometheus.Counter
+	failedResolutions prometheus.Counter
+	withdraws         prometheus.Counter
+	failedWithdraws   prometheus.Counter
+	unlocks           prometheus.Counter
+	failedUnlocks     prometheus.Counter
+}
+
+func (m *Metrics) Registry() *prometheus.Registry {
+	return m.registry
+}
+
+var _ Metricer = (*Metrics)(nil)
+
+func NewMetrics() *Metrics {
+	registry := opmetrics.NewRegistry()
+	factory := opmetrics.With(registry)
+
+	return &Metrics{
+		ns:       Namespace,
+		registry: registry,
+		factory:  factory,
+
+		TxMetrics: txmetrics.MakeTxMetrics(Namespace, factory),
+
+		CacheMetrics: opmetrics.NewCacheMetrics(factory, Namespace, "provider_cache", "Provider cache"),
+
+		ContractMetrics: contractMetrics.MakeContractMetrics(Namespace, factory),
+
+		info: *factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "info",
+			Help:      "Pseudo-metric tracking version and config info",
+		}, []string{
+			"version",
+		}),
+		up: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "up",
+			Help:      "1 if the op-dachallenger has finished starting up",
+		}),
+		challenges: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "challenges",
+			Help:      "Number of challenges made by the challenge agent",
+		}),
+		failedChallenges: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "failed_challenges",
+			Help:      "Number of challenges made by the challenge agent that have failed",
+		}),
+		resolutions: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "resolutions",
+			Help:      "Number of resolutions made by the resolver agent",
+		}),
+		failedResolutions: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "failed_resolutions",
+			Help:      "Number of resolutions made by the resolver agent that have failed",
+		}),
+		withdraws: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "withdraws",
+			Help:      "Number of withdraws made by the withdraw agent",
+		}),
+		failedWithdraws: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "failed_withdraws",
+			Help:      "Number of withdraws made by the withdraw agent that have failed",
+		}),
+		unlocks: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "unlocks",
+			Help:      "Number of unlocks made by the unlock agent",
+		}),
+		failedUnlocks: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "failed_unlocks",
+			Help:      "Number of unlocks made by the unlock agent that have failed",
+		}),
+		highestLastActedL1Block: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "highest_acted_l1_block",
+			Help:      "Highest L1 block acted on by the da challenger service",
+		}),
+		recordedL1Ref: *factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "acted_l1_refs",
+			Help:      "Tracks the L1 refs that have been acted on",
+		}, []string{
+			"block_hash",
+		}),
+	}
+}
+
+func (m *Metrics) Start(host string, port int) (*httputil.HTTPServer, error) {
+	return opmetrics.StartServer(m.registry, host, port)
+}
+
+func (m *Metrics) StartBalanceMetrics(
+	l log.Logger,
+	client *ethclient.Client,
+	account common.Address,
+) io.Closer {
+	return opmetrics.LaunchBalanceMetrics(l, m.registry, m.ns, client, account)
+}
+
+func (m *Metrics) Document() []opmetrics.DocumentedMetric {
+	return m.factory.Document()
+}
+
+func (m *Metrics) RecordDAResolve() {
+	m.resolutions.Add(1)
+}
+
+func (m *Metrics) RecordDAResolveFailed() {
+	m.failedResolutions.Add(1)
+}
+
+func (m *Metrics) RecordDAChallenge() {
+	m.challenges.Add(1)
+}
+
+func (m *Metrics) RecordDAChallengeFailed() {
+	m.failedChallenges.Add(1)
+}
+
+func (m *Metrics) RecordWithdraw() {
+	m.withdraws.Add(1)
+}
+
+func (m *Metrics) RecordWithdrawFailed() {
+	m.failedWithdraws.Add(1)
+}
+
+func (m *Metrics) RecordBondUnlock() {
+	m.unlocks.Add(1)
+}
+
+func (m *Metrics) RecordBondUnlockFailed() {
+	m.failedUnlocks.Add(1)
+}
+
+func (m *Metrics) RecordLastActedL1Block(n uint64) {
+	m.highestLastActedL1Block.Set(float64(n))
+}
+
+func (m *Metrics) RecordActedL1Ref(ref eth.L1BlockRef) {
+	m.recordedL1Ref.WithLabelValues(ref.Hash.Hex()).Set(1)
+}
+
+func (m *Metrics) RecordUp() {
+	m.up.Add(1)
+}
+
+func (m *Metrics) RecordInfo(version string) {
+	m.info.WithLabelValues(version).Set(1)
+}

--- a/op-dachallenger/service.go
+++ b/op-dachallenger/service.go
@@ -1,0 +1,290 @@
+package op_dachallenger
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/sender"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/challenge/scheduler"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/config"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-dachallenger/version"
+	plasma "github.com/ethereum-optimism/optimism/op-plasma"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/httputil"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var _ cliapp.Lifecycle = &Service{}
+
+// Service top-level service for op-dachallenger
+type Service struct {
+	logger  log.Logger
+	metrics metrics.Metricer
+
+	registry *challenge.Registry
+	actor    *challenge.Actor
+
+	txMgr    *txmgr.SimpleTxManager
+	txSender *sender.TxSender
+
+	l1Client            *ethclient.Client
+	l1Source            *sources.L1Client
+	l1EpochPollInterval time.Duration
+
+	pprofService *oppprof.Service
+	metricsSrv   *httputil.HTTPServer
+
+	balanceMetricer io.Closer
+
+	stopped atomic.Bool
+}
+
+// NewService creates a new Service.
+func NewService(ctx context.Context, logger log.Logger, cfg *config.Config, m metrics.Metricer) (*Service, error) {
+	s := &Service{
+		logger:              logger,
+		metrics:             m,
+		l1EpochPollInterval: cfg.PollInterval,
+	}
+
+	if err := s.initFromConfig(ctx, cfg); err != nil {
+		// upon initialization error we can try to close any of the service components that may have started already.
+		return nil, errors.Join(fmt.Errorf("failed to init challenger game service: %w", err), s.Stop(ctx))
+	}
+
+	return s, nil
+}
+
+func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error {
+	if err := s.initPProf(&cfg.PprofConfig); err != nil {
+		return fmt.Errorf("failed to init profiling: %w", err)
+	}
+	if err := s.initTxManager(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to init tx manager: %w", err)
+	}
+	if err := s.initL1Client(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to init l1 client: %w", err)
+	}
+	if err := s.initMetricsServer(&cfg.MetricsConfig); err != nil {
+		return fmt.Errorf("failed to init metrics server: %w", err)
+	}
+	if err := s.initRegistry(cfg); err != nil {
+		return fmt.Errorf("failed to create da contract registry: %w", err)
+	}
+	if err := s.initActor(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to init actor: %w", err)
+	}
+
+	s.metrics.RecordInfo(version.SimpleWithMeta)
+	s.metrics.RecordUp()
+	return nil
+}
+
+func (s *Service) initPProf(cfg *oppprof.CLIConfig) error {
+	s.pprofService = oppprof.New(
+		cfg.ListenEnabled,
+		cfg.ListenAddr,
+		cfg.ListenPort,
+		cfg.ProfileType,
+		cfg.ProfileDir,
+		cfg.ProfileFilename,
+	)
+
+	if err := s.pprofService.Start(); err != nil {
+		return fmt.Errorf("failed to start pprof service: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) initTxManager(ctx context.Context, cfg *config.Config) error {
+	txMgr, err := txmgr.NewSimpleTxManager("challenger", s.logger, s.metrics, cfg.TxMgrConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create the transaction manager: %w", err)
+	}
+	s.txMgr = txMgr
+	s.txSender = sender.NewTxSender(ctx, s.logger, txMgr, cfg.MaxPendingTx)
+	return nil
+}
+
+func (s *Service) initL1Client(ctx context.Context, cfg *config.Config) error {
+	l1Client, err := dial.DialEthClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, cfg.L1EthRpc)
+	if err != nil {
+		return fmt.Errorf("failed to dial L1: %w", err)
+	}
+	s.l1Client = l1Client
+	return nil
+}
+
+func (s *Service) initMetricsServer(cfg *opmetrics.CLIConfig) error {
+	if !cfg.Enabled {
+		return nil
+	}
+	s.logger.Debug("starting metrics server", "addr", cfg.ListenAddr, "port", cfg.ListenPort)
+	m, ok := s.metrics.(opmetrics.RegistryMetricer)
+	if !ok {
+		return fmt.Errorf("metrics were enabled, but metricer %T does not expose registry for metrics-server", s.metrics)
+	}
+	metricsSrv, err := opmetrics.StartServer(m.Registry(), cfg.ListenAddr, cfg.ListenPort)
+	if err != nil {
+		return fmt.Errorf("failed to start metrics server: %w", err)
+	}
+	s.logger.Info("started metrics server", "addr", metricsSrv.Addr())
+	s.metricsSrv = metricsSrv
+	s.balanceMetricer = s.metrics.StartBalanceMetrics(s.logger, s.l1Client, s.txSender.From())
+	return nil
+}
+
+func (s *Service) initRegistry(cfg *config.Config) error {
+	creator, err := challenge.NewContractCreator(cfg.PlasmaConfig.CommitmentType, cfg.CommitmentKind)
+	if err != nil {
+		return err
+	}
+	s.registry = &challenge.Registry{}
+	s.registry.RegisterBondUnlockContract(cfg.PlasmaConfig.CommitmentType, cfg.CommitmentKind,
+		creator.UnlockContractCreator)
+	s.registry.RegisterChallengeResolverContract(cfg.PlasmaConfig.CommitmentType, cfg.CommitmentKind,
+		creator.ResolveContractCreator)
+	s.registry.RegisterBondWithdrawContract(cfg.PlasmaConfig.CommitmentType, cfg.CommitmentKind,
+		creator.WithdrawContractCreator)
+	s.registry.RegisterCommitmentChallengeContract(cfg.PlasmaConfig.CommitmentType, cfg.CommitmentKind,
+		creator.ChallengeContractCreator)
+	return nil
+}
+
+func (s *Service) initActor(ctx context.Context, cfg *config.Config) error {
+	pollClient, err := client.NewRPCWithClient(ctx, s.logger, cfg.L1EthRpc, client.NewBaseRPCClient(s.l1Client.Client()), cfg.PollInterval)
+	if err != nil {
+		return fmt.Errorf("failed to create RPC client: %w", err)
+	}
+
+	l1Source, err := sources.NewL1Client(pollClient, s.logger, s.metrics, cfg.L1ClientConfig)
+	if err != nil {
+		return err
+	}
+
+	damgr := plasma.NewPlasmaDA(s.logger, *cfg.CLIConfig, *cfg.PlasmaConfig, &plasma.NoopMetrics{}) // TODO: add DA metrics
+
+	beaconClient, fallbacks, err := cfg.BlobSourceConfig.Setup(ctx, s.logger)
+	if err != nil {
+		return fmt.Errorf("failed to setup L1 Beacon API client: %w", err)
+	}
+	beaconCfg := sources.L1BeaconClientConfig{
+		FetchAllSidecars: cfg.BlobSourceConfig.ShouldFetchAllSidecars(),
+	}
+	beacon := sources.NewL1BeaconClient(beaconClient, beaconCfg, fallbacks...)
+
+	var defender *scheduler.ResolveScheduler
+	var challenger *scheduler.ChallengeScheduler
+	if cfg.Defend {
+		contract, err := s.registry.
+			CreateResolveContract[cfg.PlasmaConfig.CommitmentType][cfg.CommitmentKind](context.Background(), s.metrics,
+			cfg.PlasmaConfig.DAChallengeContractAddress, batching.NewMultiCaller(s.l1Client.Client(),
+				batching.DefaultBatchSize))
+		if err != nil {
+			return err
+		}
+		res := scheduler.NewResolver(s.logger, contract, s.txSender)
+		defender = scheduler.NewResolveScheduler(s.logger, s.metrics, res)
+	}
+	if cfg.Challenge {
+		contract, err := s.registry.
+			CreateChallengeContract[cfg.PlasmaConfig.CommitmentType][cfg.CommitmentKind](context.Background(), s.metrics,
+			cfg.PlasmaConfig.DAChallengeContractAddress, batching.NewMultiCaller(s.l1Client.Client(),
+				batching.DefaultBatchSize))
+		if err != nil {
+			return err
+		}
+		chal := scheduler.NewChallenger(s.logger, contract, s.txSender)
+		challenger = scheduler.NewChallengeScheduler(s.logger, s.metrics, chal)
+	}
+
+	actor, err := challenge.NewActor(s.logger, s.metrics, defender, challenger,
+		damgr, l1Source, beacon, cfg.RollupConfig)
+	if err != nil {
+		return err
+	}
+	s.actor = actor
+	s.l1Source = l1Source
+	return nil
+}
+
+// Start satisfies cliapp.Lifecycle
+func (s *Service) Start(ctx context.Context) error {
+	s.logger.Info("starting da challenge service")
+	s.actor.Start(ctx)
+	finalHeadSub := eth.PollBlockChanges(s.logger, s.l1Source, s.actor.OnNewL1Finalized, eth.Finalized,
+		s.l1EpochPollInterval, time.Second*10)
+	go func() {
+		for {
+			select {
+			case err := <-finalHeadSub.Err():
+				s.logger.Error("finalHeadSub error:", err)
+			default:
+				if s.stopped.Load() {
+					return
+				}
+			}
+		}
+	}()
+	s.logger.Info("challenger game service start completed")
+	return nil
+}
+
+// Stopped satisfies cliapp.Lifecycle
+func (s *Service) Stopped() bool {
+	return s.stopped.Load()
+}
+
+// Stop satisfied cliapp.Lifecycle
+func (s *Service) Stop(ctx context.Context) error {
+	s.logger.Info("stopping da challenger service")
+
+	var result error
+	if s.actor != nil {
+		if err := s.actor.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close coordinator: %w", err))
+		}
+	}
+	if s.pprofService != nil {
+		if err := s.pprofService.Stop(ctx); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close pprof server: %w", err))
+		}
+	}
+	if s.balanceMetricer != nil {
+		if err := s.balanceMetricer.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close balance metricer: %w", err))
+		}
+	}
+	if s.txMgr != nil {
+		s.txMgr.Close()
+	}
+	if s.l1Client != nil {
+		s.l1Client.Close()
+	}
+	if s.metricsSrv != nil {
+		if err := s.metricsSrv.Stop(ctx); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close metrics server: %w", err))
+		}
+	}
+	s.stopped.Store(true)
+
+	s.logger.Info("stopped challenger game service", "err", result)
+	return result
+}

--- a/op-dachallenger/version/version.go
+++ b/op-dachallenger/version/version.go
@@ -1,0 +1,14 @@
+package version
+
+var (
+	Version = "v0.0.0"
+	Meta    = "dev"
+)
+
+var SimpleWithMeta = func() string {
+	v := Version
+	if Meta != "" {
+		v += "-" + Meta
+	}
+	return v
+}()

--- a/op-node/rollup/derive/blob_data_source.go
+++ b/op-node/rollup/derive/blob_data_source.go
@@ -121,7 +121,7 @@ func dataAndHashesFromTxs(txs types.Transactions, config *DataSourceConfig, batc
 	blobIndex := 0 // index of each blob in the block's blob sidecar
 	for _, tx := range txs {
 		// skip any non-batcher transactions
-		if !isValidBatchTx(tx, config.l1Signer, config.batchInboxAddress, batcherAddr) {
+		if !isValidBatchTx(tx, config.L1Signer, config.BatchInboxAddress, batcherAddr) {
 			blobIndex += len(tx.BlobHashes())
 			continue
 		}

--- a/op-node/rollup/derive/blob_data_source_test.go
+++ b/op-node/rollup/derive/blob_data_source_test.go
@@ -27,8 +27,8 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	chainId := new(big.Int).SetUint64(rng.Uint64())
 	signer := types.NewCancunSigner(chainId)
 	config := DataSourceConfig{
-		l1Signer:          signer,
-		batchInboxAddress: batchInboxAddr,
+		L1Signer:          signer,
+		BatchInboxAddress: batchInboxAddr,
 	}
 
 	// create a valid non-blob batcher transaction and make sure it's picked up

--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -79,7 +79,7 @@ func (ds *CalldataSource) Next(ctx context.Context) (eth.Data, error) {
 func DataFromEVMTransactions(dsCfg DataSourceConfig, batcherAddr common.Address, txs types.Transactions, log log.Logger) []eth.Data {
 	out := []eth.Data{}
 	for _, tx := range txs {
-		if isValidBatchTx(tx, dsCfg.l1Signer, dsCfg.batchInboxAddress, batcherAddr) {
+		if isValidBatchTx(tx, dsCfg.L1Signer, dsCfg.BatchInboxAddress, batcherAddr) {
 			out = append(out, tx.Data())
 		}
 	}

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -49,9 +49,9 @@ type DataSourceFactory struct {
 
 func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1Fetcher, blobsFetcher L1BlobsFetcher, plasmaFetcher PlasmaInputFetcher) *DataSourceFactory {
 	config := DataSourceConfig{
-		l1Signer:          cfg.L1Signer(),
-		batchInboxAddress: cfg.BatchInboxAddress,
-		plasmaEnabled:     cfg.PlasmaEnabled(),
+		L1Signer:          cfg.L1Signer(),
+		BatchInboxAddress: cfg.BatchInboxAddress,
+		PlasmaEnabled:     cfg.PlasmaEnabled(),
 	}
 	return &DataSourceFactory{
 		log:           log,
@@ -76,7 +76,7 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, b
 	} else {
 		src = NewCalldataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ref, batcherAddr)
 	}
-	if ds.dsCfg.plasmaEnabled {
+	if ds.dsCfg.PlasmaEnabled {
 		// plasma([calldata | blobdata](l1Ref)) -> data
 		return NewPlasmaDataSource(ds.log, src, ds.fetcher, ds.plasmaFetcher, ref), nil
 	}
@@ -85,9 +85,9 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, b
 
 // DataSourceConfig regroups the mandatory rollup.Config fields needed for DataFromEVMTransactions.
 type DataSourceConfig struct {
-	l1Signer          types.Signer
-	batchInboxAddress common.Address
-	plasmaEnabled     bool
+	L1Signer          types.Signer
+	BatchInboxAddress common.Address
+	PlasmaEnabled     bool
 }
 
 // isValidBatchTx returns true if:

--- a/op-node/rollup/derive/plasma_data_source.go
+++ b/op-node/rollup/derive/plasma_data_source.go
@@ -84,7 +84,7 @@ func (s *PlasmaDataSource) Next(ctx context.Context) (eth.Data, error) {
 		return s.Next(ctx)
 	} else if errors.Is(err, plasma.ErrMissingPastWindow) {
 		return nil, NewCriticalError(fmt.Errorf("data for comm %s not available: %w", s.comm, err))
-	} else if errors.Is(err, plasma.ErrPendingChallenge) {
+	} else if errors.Is(err, plasma.ErrPendingChallenge) || errors.Is(err, plasma.ErrActiveChallenge) {
 		// continue stepping without slowing down.
 		return nil, NotEnoughData
 	} else if err != nil {

--- a/op-plasma/damgr.go
+++ b/op-plasma/damgr.go
@@ -20,6 +20,9 @@ import (
 // so derivation should halt temporarily.
 var ErrPendingChallenge = errors.New("not found, pending challenge")
 
+// ErrActiveChallenge is returned when data is not available but there is already an active challenge
+var ErrActiveChallenge = errors.New("not found, active challenge")
+
 // ErrExpiredChallenge is returned when a challenge was not resolved and derivation should skip this input.
 var ErrExpiredChallenge = errors.New("challenge expired")
 
@@ -238,7 +241,7 @@ func (d *DA) GetInput(ctx context.Context, l1 L1Fetcher, comm CommitmentData, bl
 			if err := d.LookAhead(ctx, l1); err != nil {
 				return nil, err
 			}
-			return nil, ErrPendingChallenge
+			return nil, ErrActiveChallenge
 		case ChallengeResolved:
 			// Generic Commitments don't resolve from L1 so if we still can't find the data we're out of luck
 			if comm.CommitmentType() == GenericCommitmentType {
@@ -257,6 +260,11 @@ func (d *DA) GetInput(ctx context.Context, l1 L1Fetcher, comm CommitmentData, bl
 	}
 
 	return data, nil
+}
+
+// GetChallengeStatus exposes the underlying state.GetChallengeStatus method
+func (d *DA) GetChallengeStatus(comm CommitmentData, commBlockNumber uint64) ChallengeStatus {
+	return d.state.GetChallengeStatus(comm, commBlockNumber)
 }
 
 // AdvanceChallengeOrigin reads & stores challenge events for the given L1 block

--- a/packages/contracts-bedrock/snapshots/abi_loader.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader.go
@@ -28,6 +28,9 @@ var systemConfig []byte
 //go:embed abi/CrossL2Inbox.json
 var crossL2Inbox []byte
 
+//go:embed abi/DataAvailabilityChallenge.json
+var daChallenge []byte
+
 func LoadDisputeGameFactoryABI() *abi.ABI {
 	return loadABI(disputeGameFactory)
 }
@@ -50,6 +53,10 @@ func LoadSystemConfigABI() *abi.ABI {
 
 func LoadCrossL2InboxABI() *abi.ABI {
 	return loadABI(crossL2Inbox)
+}
+
+func LoadDAChallengeABI() *abi.ABI {
+	return loadABI(daChallenge)
 }
 
 func loadABI(json []byte) *abi.ABI {

--- a/packages/contracts-bedrock/snapshots/abi_loader_test.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader_test.go
@@ -17,6 +17,7 @@ func TestLoadABIs(t *testing.T) {
 		{"PreimageOracle", LoadPreimageOracleABI},
 		{"MIPS", LoadMIPSABI},
 		{"DelayedWETH", LoadDelayedWETHABI},
+		{"DataAvailabilityChallenge", LoadDAChallengeABI},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
op-dachallenger service for https://github.com/polymerdao/roadmap/issues/34 and https://github.com/polymerdao/roadmap/issues/35 (supports challenging unavailable commitments and resolving available challenges).

In challenge mode it listens for new finalized blocks and inspects these blocks for new altDA commitments posted to the batcher inbox, if the data cannot be retrieved at that time it will create a new challenge.

In defender mode it listen for new finalized blocks and inspects these blocks for active altDA challenges, if it can retrieve the corresponding data at that time it will resolve the challenge.

Very minimal changes were made to existing op packages, namely exposure of the previously private fields in `DataSourceConfig` (this shouldn't be too contentious, the struct itself is already exported but all its fields are private and have no public setter/getter methods); adding a `GetChallengeStatus` method to the `damgr.DA` to expose the underling `state.GetChallengeStatus` method; and returning a new error type `ErrActiveChallenge` from `damgr.DA.GetInput` to differentiate between the case where DA could not be retrieved but a challenge is active vs a challenge is uninitialized. 

TODO:
1. Finish unit tests (only have contract binding tests atm)
2. e2e test suite
3. Consider adding retry logic:
    * If active challenge can't be immediately resolved continue to try to fetch the missing data until resolve_window expires
    * If commitment data can't be immediately retrieved continue to try to fetch the missing data until challenge_window is closer to expiring before opening a challenge against it