### PR TITLE
feat: update frame validity check to account for altDA

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -164,7 +164,7 @@ func (c *CLIConfig) Check() error {
 
 // NewConfig parses the Config from the provided flags or environment variables.
 func NewConfig(ctx *cli.Context) *CLIConfig {
-	return &CLIConfig{
+	cfg := &CLIConfig{
 		/* Required Flags */
 		L1EthRpc:        ctx.String(flags.L1EthRpcFlag.Name),
 		L2EthRpc:        ctx.String(flags.L2EthRpcFlag.Name),
@@ -194,4 +194,11 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		RPC:                          oprpc.ReadCLIConfig(ctx),
 		AltDA:                        altda.ReadCLIConfig(ctx),
 	}
+
+	// altDA specific settings
+	if cfg.AltDA.Enabled {
+		derive.SetMaxFrameLenForAllDA(altda.MaxInputSize)
+	}
+
+	return cfg
 }

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/flags"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
@@ -182,6 +183,10 @@ func (cfg *Config) Check() error {
 	}
 	if cfg.AltDA.Enabled {
 		log.Warn("Alt-DA Mode is a Beta feature of the MIT licensed OP Stack.  While it has received initial review from core contributors, it is still undergoing testing, and may have bugs or other issues.")
+
+		// Update the max frame size for altDA mode; otherwise channel frames from altDA are likely to exceed the
+		// default max frame size (1MB) and thus get discarded by op-node during block derivation.
+		derive.SetMaxFrameLenForAllDA(altda.MaxInputSize)
 	}
 	return nil
 }

--- a/op-node/rollup/derive/frame.go
+++ b/op-node/rollup/derive/frame.go
@@ -13,6 +13,26 @@ import (
 // but we leave space to grow larger anyway (gas limit allows for more data).
 const MaxFrameLen = 1_000_000
 
+/**
+When altDA is enabled, the max frame length is determined by the altDA provider instead of L1 Tx limit.
+A final L1 tx only includes an altDA commitment, not the original channel frame data sent to altDA.
+*/
+
+// maxFrameLenForAllDA is the maximum frame length for both ethDA and altDA.
+// It defaults to MaxFrameLen, but should be overriden with `SetMaxFrameLenForAllDA(..)` if altDA is enabled.
+var maxFrameLenForAllDA uint32 = MaxFrameLen
+
+// GetMaxFrameLenForAllDA returns the maximum frame length for both ethDA and altDA
+func GetMaxFrameLenForAllDA() uint32 {
+	return maxFrameLenForAllDA
+}
+
+// SetMaxFrameLenForAllDA sets the maximum frame length for both ethDA and altDA
+// This should be called if altDA is enabled.
+func SetMaxFrameLenForAllDA(maxFrameLen uint32) {
+	maxFrameLenForAllDA = maxFrameLen
+}
+
 // Data Format
 //
 // frame = channel_id ++ frame_number ++ frame_data_length ++ frame_data ++ is_last
@@ -85,9 +105,9 @@ func (f *Frame) UnmarshalBinary(r ByteReader) error {
 		return fmt.Errorf("reading frame_data_length: %w", eofAsUnexpectedMissing(err))
 	}
 
-	// Cap frame length to MaxFrameLen (currently 1MB)
-	if frameLength > MaxFrameLen {
-		return fmt.Errorf("frame_data_length is too large: %d", frameLength)
+	// Cap frame length to GetMaxFrameLenForAllDA
+	if frameLength > GetMaxFrameLenForAllDA() {
+		return fmt.Errorf("frame_data_length is too large: %d, capped at %d", frameLength, GetMaxFrameLenForAllDA())
 	}
 	f.Data = make([]byte, int(frameLength))
 	if _, err := io.ReadFull(r, f.Data); err != nil {


### PR DESCRIPTION
## What
channel frame validity check in op-node derivation, which is done when Frame is unmarshaled.

## Why
the original logic works fine for ethDA, but applies an unnecessary low cap to channel frame size when altDA is enabled. 