### PR TITLE
Typo fix  CHANGELOG.md

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -241,7 +241,7 @@
 
 ### Minor Changes
 
-- c975c9620: Add suppory for finalizing legacy withdrawals after the Bedrock migration
+- c975c9620: Add support for finalizing legacy withdrawals after the Bedrock migration
 
 ### Patch Changes
 


### PR DESCRIPTION
# Pull Request: Typo Fix in CHANGELOG.md

## Description
This pull request corrects a typo in the `CHANGELOG.md` file. The word **"suppory"** has been corrected to **"support"** in the following context:

### Before:
> Add **suppory** for finalizing legacy withdrawals after the Bedrock migration.

### After:
> Add **support** for finalizing legacy withdrawals after the Bedrock migration.
