### PR TITLE
op-node: add p2p ExecutionPayloadWrapper

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -639,12 +639,12 @@ func (n *OpNode) PublishL2Payload(ctx context.Context, envelope *eth.ExecutionPa
 	return nil
 }
 
-func (n *OpNode) OnUnsafeL2Payload(ctx context.Context, from peer.ID, envelope *eth.ExecutionPayloadEnvelope) error {
+func (n *OpNode) OnUnsafeL2Payload(ctx context.Context, from peer.ID, wrapper *p2p.ExecutionPayloadWrapper) error {
 	// ignore if it's from ourselves
 	if p2pNode := n.getP2PNodeIfEnabled(); p2pNode != nil && from == p2pNode.Host().ID() {
 		return nil
 	}
-
+	envelope := wrapper.Envelope
 	n.tracer.OnUnsafeL2Payload(ctx, from, envelope)
 
 	n.log.Info("Received signed execution payload from p2p", "id", envelope.ExecutionPayload.ID(), "peer", from,

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -421,8 +421,17 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		// but validator concurrency is limited anyway)
 		seen.markSeen(payload.BlockHash)
 
+		// make sure to copy the raw data over to prevent it from being overwritten by other threads later on
+		rawdata := make([]byte, len(data))
+		copy(rawdata, data)
+		wrapper := ExecutionPayloadWrapper{
+			Envelope:     &envelope,
+			RawData:      rawdata,
+			BlockVersion: blockVersion,
+		}
+
 		// remember the decoded payload for later usage in topic subscriber.
-		message.ValidatorData = &envelope
+		message.ValidatorData = &wrapper
 		return pubsub.ValidationAccept
 	}
 }
@@ -456,8 +465,15 @@ func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 	return pubsub.ValidationAccept
 }
 
+// This is used by our p2p-sentry-db to get access to the signature and signed payload
+type ExecutionPayloadWrapper struct {
+	Envelope     *eth.ExecutionPayloadEnvelope
+	RawData      []byte
+	BlockVersion eth.BlockVersion
+}
+
 type GossipIn interface {
-	OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error
+	OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg *ExecutionPayloadWrapper) error
 }
 
 type GossipTopicInfo interface {
@@ -686,9 +702,9 @@ func newBlockTopic(ctx context.Context, topicId string, ps *pubsub.PubSub, log l
 type TopicSubscriber func(ctx context.Context, sub *pubsub.Subscription)
 type MessageHandler func(ctx context.Context, from peer.ID, msg any) error
 
-func BlocksHandler(onBlock func(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error) MessageHandler {
+func BlocksHandler(onBlock func(ctx context.Context, from peer.ID, msg *ExecutionPayloadWrapper) error) MessageHandler {
 	return func(ctx context.Context, from peer.ID, msg any) error {
-		payload, ok := msg.(*eth.ExecutionPayloadEnvelope)
+		payload, ok := msg.(*ExecutionPayloadWrapper)
 		if !ok {
 			return fmt.Errorf("expected topic validator to parse and validate data into execution payload, but got %T", msg)
 		}

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -77,9 +77,9 @@ type mockGossipIn struct {
 	OnUnsafeL2PayloadFn func(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error
 }
 
-func (m *mockGossipIn) OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error {
+func (m *mockGossipIn) OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg *ExecutionPayloadWrapper) error {
 	if m.OnUnsafeL2PayloadFn != nil {
-		return m.OnUnsafeL2PayloadFn(ctx, from, msg)
+		return m.OnUnsafeL2PayloadFn(ctx, from, msg.Envelope)
 	}
 	return nil
 }

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -96,7 +96,7 @@ func MakeStreamHandler(resourcesCtx context.Context, log log.Logger, fn requestH
 
 type newStreamFn func(ctx context.Context, peerId peer.ID, protocolId ...protocol.ID) (network.Stream, error)
 
-type receivePayloadFn func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error
+type receivePayloadFn func(ctx context.Context, from peer.ID, payload *ExecutionPayloadWrapper) error
 
 type rangeRequest struct {
 	start uint64
@@ -508,7 +508,8 @@ func (s *SyncClient) tryPromote(h common.Hash) {
 func (s *SyncClient) promote(ctx context.Context, res syncResult) {
 	s.log.Debug("promoting p2p sync result", "payload", res.payload.ExecutionPayload.ID(), "peer", res.peer)
 
-	if err := s.receivePayload(ctx, res.peer, res.payload); err != nil {
+	wrapper := ExecutionPayloadWrapper{Envelope: res.payload}
+	if err := s.receivePayload(ctx, res.peer, &wrapper); err != nil {
 		s.log.Warn("failed to promote payload, receiver error", "err", err)
 		return
 	}

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -141,8 +141,8 @@ func TestSinglePeerSync(t *testing.T) {
 
 	// collect received payloads in a buffered channel, so we can verify we get everything
 	received := make(chan *eth.ExecutionPayloadEnvelope, 100)
-	receivePayload := receivePayloadFn(func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
-		received <- payload
+	receivePayload := receivePayloadFn(func(ctx context.Context, from peer.ID, payload *ExecutionPayloadWrapper) error {
+		received <- payload.Envelope
 		return nil
 	})
 
@@ -214,8 +214,8 @@ func TestMultiPeerSync(t *testing.T) {
 
 		// collect received payloads in a buffered channel, so we can verify we get everything
 		received := make(chan *eth.ExecutionPayloadEnvelope, 100)
-		receivePayload := receivePayloadFn(func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
-			received <- payload
+		receivePayload := receivePayloadFn(func(ctx context.Context, from peer.ID, payload *ExecutionPayloadWrapper) error {
+			received <- payload.Envelope
 			return nil
 		})
 
@@ -368,7 +368,7 @@ func TestNetworkNotifyAddPeerAndRemovePeer(t *testing.T) {
 	require.NoError(t, err, "failed to launch host B")
 	defer hostB.Close()
 
-	syncCl := NewSyncClient(log, cfg, hostA, func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
+	syncCl := NewSyncClient(log, cfg, hostA, func(ctx context.Context, from peer.ID, payload *ExecutionPayloadWrapper) error {
 		return nil
 	}, metrics.NoopMetrics, &NoopApplicationScorer{})
 

--- a/op-node/rollup/status/l1_tracker_test.go
+++ b/op-node/rollup/status/l1_tracker_test.go
@@ -23,7 +23,7 @@ func newL1HeadEvent(l1Tracker *L1Tracker, head eth.L1BlockRef) {
 func TestCachingHeadReorg(t *testing.T) {
 	ctx := context.Background()
 	l1Fetcher := &testutils.MockL1Source{}
-	l1Tracker := NewL1Tracker(l1Fetcher)
+	l1Tracker := NewL1Tracker(l1Fetcher, 1000)
 
 	// no blocks added to cache yet
 	l1Head := mockL1BlockRef(99)
@@ -71,7 +71,7 @@ func TestCachingHeadReorg(t *testing.T) {
 func TestCachingHeadRewind(t *testing.T) {
 	ctx := context.Background()
 	l1Fetcher := &testutils.MockL1Source{}
-	l1Tracker := NewL1Tracker(l1Fetcher)
+	l1Tracker := NewL1Tracker(l1Fetcher, 1000)
 
 	// no blocks added to cache yet
 	l1Head := mockL1BlockRef(99)
@@ -126,7 +126,7 @@ func TestCachingHeadRewind(t *testing.T) {
 func TestCachingChainShorteningReorg(t *testing.T) {
 	ctx := context.Background()
 	l1Fetcher := &testutils.MockL1Source{}
-	l1Tracker := NewL1Tracker(l1Fetcher)
+	l1Tracker := NewL1Tracker(l1Fetcher, 1000)
 
 	// no blocks added to cache yet
 	l1Head := mockL1BlockRef(99)
@@ -176,7 +176,7 @@ func TestCachingChainShorteningReorg(t *testing.T) {
 func TestCachingDeepReorg(t *testing.T) {
 	ctx := context.Background()
 	l1Fetcher := &testutils.MockL1Source{}
-	l1Tracker := NewL1Tracker(l1Fetcher)
+	l1Tracker := NewL1Tracker(l1Fetcher, 1000)
 
 	// from cache
 	l1Head := mockL1BlockRef(100)
@@ -226,7 +226,7 @@ func TestCachingDeepReorg(t *testing.T) {
 func TestCachingSkipAhead(t *testing.T) {
 	ctx := context.Background()
 	l1Fetcher := &testutils.MockL1Source{}
-	l1Tracker := NewL1Tracker(l1Fetcher)
+	l1Tracker := NewL1Tracker(l1Fetcher, 1000)
 
 	// from cache
 	l1Head := mockL1BlockRef(100)
@@ -261,7 +261,7 @@ func TestCachingSkipAhead(t *testing.T) {
 func TestCacheSizeEviction(t *testing.T) {
 	ctx := context.Background()
 	l1Fetcher := &testutils.MockL1Source{}
-	l1Tracker := NewL1Tracker(l1Fetcher)
+	l1Tracker := NewL1Tracker(l1Fetcher, 1000)
 
 	// insert 1000 elements into the cache
 	for idx := 1000; idx < 2000; idx++ {


### PR DESCRIPTION
Our current version of p2p-sentry-db duplicates a lot of the logic from op-node/p2p package which is
not great.

The main reason why we had to do that was because the callback we can install into the p2p layer
does not get access to the actual signed payload, only the `eth.ExecutionPayloadEnvelope`

This PR modifies the `p2p.GossipIn` interface so it does get access to a wrapper of
`eth.ExecutionPayloadEnvelope` that does contain everything `p2p-sentry-db` needs.

Tests have also being modified to keep working.
